### PR TITLE
Add sync outbox and incremental invoice synchronization

### DIFF
--- a/app/src/main/java/com/example/selliaapp/data/dao/InvoiceDao.kt
+++ b/app/src/main/java/com/example/selliaapp/data/dao/InvoiceDao.kt
@@ -33,6 +33,16 @@ interface InvoiceDao {
     @Query("SELECT * FROM invoices ORDER BY dateMillis DESC, id DESC")
     fun getAllInvoices(): Flow<List<InvoiceWithItems>>
 
+    @Transaction
+    @Query("SELECT * FROM invoices ORDER BY dateMillis DESC, id DESC")
+    suspend fun getAllInvoicesOnce(): List<InvoiceWithItems>
+
+    @Transaction
+    @Query(
+        "SELECT * FROM invoices WHERE id IN (:ids) ORDER BY dateMillis DESC, id DESC"
+    )
+    suspend fun getInvoicesWithItemsByIds(ids: List<Long>): List<InvoiceWithItems>
+
     @Insert(onConflict = OnConflictStrategy.ABORT)
     suspend fun insertInvoiceItems(items: List<InvoiceItem>)
 

--- a/app/src/main/java/com/example/selliaapp/data/dao/InvoiceItemDao.kt
+++ b/app/src/main/java/com/example/selliaapp/data/dao/InvoiceItemDao.kt
@@ -13,8 +13,8 @@ interface InvoiceItemDao {
     suspend fun insertAll(items: List<InvoiceItem>)
 
     @Query("DELETE FROM invoice_items WHERE invoiceId = :invoiceId")
-    suspend fun deleteByInvoiceId(invoiceId: Int)
+    suspend fun deleteByInvoiceId(invoiceId: Long)
 
     @Query("SELECT * FROM invoice_items WHERE invoiceId = :invoiceId")
-    suspend fun getByInvoiceId(invoiceId: Int): List<InvoiceItem>
+    suspend fun getByInvoiceId(invoiceId: Long): List<InvoiceItem>
 }

--- a/app/src/main/java/com/example/selliaapp/data/dao/ProductDao.kt
+++ b/app/src/main/java/com/example/selliaapp/data/dao/ProductDao.kt
@@ -32,6 +32,9 @@ interface ProductDao {
     @Query("SELECT * FROM products WHERE id = :id")
     suspend fun getById(id: Int): ProductEntity?
 
+    @Query("SELECT * FROM products WHERE id IN (:ids)")
+    suspend fun getByIds(ids: List<Int>): List<ProductEntity>
+
     @Query("SELECT * FROM products WHERE barcode = :barcode LIMIT 1")
     suspend fun getByBarcodeOnce(barcode: String): ProductEntity?
 

--- a/app/src/main/java/com/example/selliaapp/data/dao/StockMovementDao.kt
+++ b/app/src/main/java/com/example/selliaapp/data/dao/StockMovementDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.example.selliaapp.data.local.entity.StockMovementEntity
+import com.example.selliaapp.data.model.stock.StockMovementWithProduct
 import kotlinx.coroutines.flow.Flow
 import java.time.Instant
 
@@ -22,4 +23,42 @@ interface StockMovementDao {
 
     @Query("SELECT * FROM stock_movements ORDER BY ts DESC LIMIT :limit")
     fun observeRecent(limit: Int = 100): Flow<List<StockMovementEntity>>
+
+    @Query(
+        """
+        SELECT sm.id AS id,
+               sm.productId AS productId,
+               p.name AS productName,
+               sm.delta AS delta,
+               sm.reason AS reason,
+               sm.note AS note,
+               sm.ts AS ts
+        FROM stock_movements sm
+        INNER JOIN products p ON p.id = sm.productId
+        ORDER BY sm.ts DESC
+        LIMIT :limit
+        """
+    )
+    fun observeRecentDetailed(limit: Int = 50): Flow<List<StockMovementWithProduct>>
+
+    @Query(
+        """
+        SELECT sm.id AS id,
+               sm.productId AS productId,
+               p.name AS productName,
+               sm.delta AS delta,
+               sm.reason AS reason,
+               sm.note AS note,
+               sm.ts AS ts
+        FROM stock_movements sm
+        INNER JOIN products p ON p.id = sm.productId
+        WHERE sm.productId = :productId
+        ORDER BY sm.ts DESC
+        LIMIT :limit
+        """
+    )
+    fun observeByProductDetailed(
+        productId: Int,
+        limit: Int = 20
+    ): Flow<List<StockMovementWithProduct>>
 }

--- a/app/src/main/java/com/example/selliaapp/data/dao/SyncOutboxDao.kt
+++ b/app/src/main/java/com/example/selliaapp/data/dao/SyncOutboxDao.kt
@@ -1,0 +1,39 @@
+package com.example.selliaapp.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.example.selliaapp.data.local.entity.SyncOutboxEntity
+
+@Dao
+interface SyncOutboxDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(entry: SyncOutboxEntity)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsertAll(entries: List<SyncOutboxEntity>)
+
+    @Query("SELECT * FROM sync_outbox ORDER BY createdAt ASC")
+    suspend fun getAll(): List<SyncOutboxEntity>
+
+    @Query("SELECT * FROM sync_outbox WHERE entityType = :entityType ORDER BY createdAt ASC")
+    suspend fun getByType(entityType: String): List<SyncOutboxEntity>
+
+    @Query(
+        "DELETE FROM sync_outbox WHERE entityType = :entityType AND entityId IN (:entityIds)"
+    )
+    suspend fun deleteByTypeAndIds(entityType: String, entityIds: List<Long>)
+
+    @Query(
+        "UPDATE sync_outbox SET attempts = attempts + 1, lastAttemptAt = :timestamp, lastError = :error " +
+            "WHERE entityType = :entityType AND entityId IN (:entityIds)"
+    )
+    suspend fun markAttempt(
+        entityType: String,
+        entityIds: List<Long>,
+        timestamp: Long,
+        error: String?
+    )
+}

--- a/app/src/main/java/com/example/selliaapp/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/selliaapp/data/database/AppDatabase.kt
@@ -14,6 +14,7 @@ import com.example.selliaapp.data.dao.ProviderDao
 import com.example.selliaapp.data.dao.ProviderInvoiceDao
 import com.example.selliaapp.data.dao.ReportDataDao
 import com.example.selliaapp.data.dao.StockMovementDao
+import com.example.selliaapp.data.dao.SyncOutboxDao
 import com.example.selliaapp.data.dao.UserDao
 import com.example.selliaapp.data.dao.VariantDao
 import com.example.selliaapp.data.local.converters.Converters
@@ -24,6 +25,7 @@ import com.example.selliaapp.data.local.entity.ProductEntity
 import com.example.selliaapp.data.local.entity.ProviderEntity
 import com.example.selliaapp.data.local.entity.ReportDataEntity
 import com.example.selliaapp.data.local.entity.StockMovementEntity
+import com.example.selliaapp.data.local.entity.SyncOutboxEntity
 import com.example.selliaapp.data.local.entity.VariantEntity
 import com.example.selliaapp.data.model.ExpenseRecord
 import com.example.selliaapp.data.model.ExpenseTemplate
@@ -47,6 +49,7 @@ import com.example.selliaapp.data.model.User
         StockMovementEntity::class,
         CategoryEntity::class,
         VariantEntity::class,
+        SyncOutboxEntity::class,
 
         // Tablas de negocio basadas en modelos (ya tienen @Entity)
         Invoice::class,
@@ -57,7 +60,7 @@ import com.example.selliaapp.data.model.User
         ProviderInvoiceItem::class,
         User::class
     ],
-    version = 23,
+    version = 25,
     //autoMigrations = [AutoMigration(from = 1, to = 2)],
     exportSchema = true
 )
@@ -76,5 +79,6 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun stockMovementDao(): StockMovementDao
     abstract fun categoryDao(): CategoryDao
     abstract fun variantDao(): VariantDao
+    abstract fun syncOutboxDao(): SyncOutboxDao
 }
 

--- a/app/src/main/java/com/example/selliaapp/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/selliaapp/data/database/AppDatabase.kt
@@ -60,7 +60,7 @@ import com.example.selliaapp.data.model.User
         ProviderInvoiceItem::class,
         User::class
     ],
-    version = 25,
+    version = 26,
     //autoMigrations = [AutoMigration(from = 1, to = 2)],
     exportSchema = true
 )

--- a/app/src/main/java/com/example/selliaapp/data/local/entity/StockMovementEntity.kt
+++ b/app/src/main/java/com/example/selliaapp/data/local/entity/StockMovementEntity.kt
@@ -32,5 +32,6 @@ data class StockMovementEntity(
     val delta: Int,             // >0 entrada, <0 salida
     val reason: String,         // ejemplo: "CSV_APPEND", "CSV_REPLACE", "SALE", "ADJUST", "SCAN_ADD"
     val ts: Instant = Instant.now(),
-    val user: String? = null    // opcional: operador
+    val user: String? = null,   // opcional: operador
+    val note: String? = null    // detalle libre del ajuste
 )

--- a/app/src/main/java/com/example/selliaapp/data/local/entity/SyncOutboxEntity.kt
+++ b/app/src/main/java/com/example/selliaapp/data/local/entity/SyncOutboxEntity.kt
@@ -1,0 +1,28 @@
+package com.example.selliaapp.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+/**
+ * Entrada de outbox para sincronización pendiente.
+ * Permite reintentar subidas a Firestore en background.
+ */
+@Entity(
+    tableName = "sync_outbox",
+    indices = [Index(value = ["entityType", "entityId"], unique = true)]
+)
+data class SyncOutboxEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0L,
+    val entityType: String,
+    val entityId: Long,
+    val createdAt: Long = System.currentTimeMillis(),
+    val attempts: Int = 0,
+    val lastAttemptAt: Long? = null,
+    val lastError: String? = null
+)
+
+enum class SyncEntityType(val storageKey: String) {
+    PRODUCT("product"),
+    INVOICE("invoice");
+}

--- a/app/src/main/java/com/example/selliaapp/data/model/Invoice.kt
+++ b/app/src/main/java/com/example/selliaapp/data/model/Invoice.kt
@@ -22,8 +22,16 @@ import androidx.room.PrimaryKey
 
 data class Invoice(
     @PrimaryKey(autoGenerate = true) val id: Long = 0L,
-    val dateMillis: Long ,
-    val customerId: Int? ,
-    val customerName: String? ,
-    val total: Double
+    val dateMillis: Long,
+    val customerId: Int?,
+    val customerName: String?,
+    val subtotal: Double,
+    val taxes: Double,
+    val discountPercent: Int,
+    val discountAmount: Double,
+    val surchargePercent: Int,
+    val surchargeAmount: Double,
+    val total: Double,
+    val paymentMethod: String,
+    val paymentNotes: String?
 )

--- a/app/src/main/java/com/example/selliaapp/data/model/sales/InvoiceDraft.kt
+++ b/app/src/main/java/com/example/selliaapp/data/model/sales/InvoiceDraft.kt
@@ -9,6 +9,12 @@ data class InvoiceDraft(
     val subtotal: Double,
     val taxes: Double,
     val total: Double,
+    val discountPercent: Int = 0,
+    val discountAmount: Double = 0.0,
+    val surchargePercent: Int = 0,
+    val surchargeAmount: Double = 0.0,
+    val paymentMethod: String = "",
+    val paymentNotes: String? = null,
     val customerId: Long? = null,
     val customerName: String? = null
 )

--- a/app/src/main/java/com/example/selliaapp/data/model/stock/StockMovementReasons.kt
+++ b/app/src/main/java/com/example/selliaapp/data/model/stock/StockMovementReasons.kt
@@ -1,0 +1,44 @@
+package com.example.selliaapp.data.model.stock
+
+/**
+ * Catálogo de códigos de movimientos de stock para uso consistente entre capas.
+ */
+object StockMovementReasons {
+    const val PRODUCT_CREATE = "PRODUCT_CREATE"
+    const val PRODUCT_UPDATE = "PRODUCT_UPDATE"
+    const val MANUAL_ADJUST = "MANUAL_ADJUST"
+    const val INVENTORY_COUNT = "INVENTORY_COUNT"
+    const val DAMAGE = "DAMAGE"
+    const val MANUAL_RECEIVE = "MANUAL_RECEIVE"
+    const val CSV_IMPORT = "CSV_IMPORT"
+    const val QUICK_ORDER_RECEIVED = "QUICK_ORDER_RECEIVED"
+    const val SCAN_ADJUST = "SCAN_ADJUST"
+    const val SALE = "SALE"
+
+    /**
+     * Devuelve una etiqueta legible para mostrar en la UI.
+     */
+    fun humanReadable(code: String): String = when (code) {
+        PRODUCT_CREATE -> "Alta de producto"
+        PRODUCT_UPDATE -> "Edición de producto"
+        MANUAL_ADJUST -> "Ajuste manual"
+        INVENTORY_COUNT -> "Reconteo de inventario"
+        DAMAGE -> "Producto dañado"
+        MANUAL_RECEIVE -> "Mercadería recibida"
+        CSV_IMPORT -> "Importación CSV"
+        QUICK_ORDER_RECEIVED -> "Orden rápida recibida"
+        SCAN_ADJUST -> "Ajuste por escaneo"
+        SALE -> "Venta"
+        else -> code.replace('_', ' ').lowercase().replaceFirstChar { it.uppercase() }
+    }
+}
+
+/**
+ * Razones disponibles para ajustes manuales desde la UI.
+ */
+enum class StockAdjustmentReason(val code: String, val label: String) {
+    INVENTORY(StockMovementReasons.INVENTORY_COUNT, "Reconteo de inventario"),
+    DAMAGE(StockMovementReasons.DAMAGE, "Producto dañado"),
+    RECEIVED(StockMovementReasons.MANUAL_RECEIVE, "Mercadería recibida"),
+    OTHER(StockMovementReasons.MANUAL_ADJUST, "Ajuste manual");
+}

--- a/app/src/main/java/com/example/selliaapp/data/model/stock/StockMovementWithProduct.kt
+++ b/app/src/main/java/com/example/selliaapp/data/model/stock/StockMovementWithProduct.kt
@@ -1,0 +1,16 @@
+package com.example.selliaapp.data.model.stock
+
+import java.time.Instant
+
+/**
+ * Movimiento de stock acompañado del nombre del producto.
+ */
+data class StockMovementWithProduct(
+    val id: Long,
+    val productId: Int,
+    val productName: String,
+    val delta: Int,
+    val reason: String,
+    val note: String?,
+    val ts: Instant
+)

--- a/app/src/main/java/com/example/selliaapp/data/remote/InvoiceFirestoreMappers.kt
+++ b/app/src/main/java/com/example/selliaapp/data/remote/InvoiceFirestoreMappers.kt
@@ -1,0 +1,85 @@
+package com.example.selliaapp.data.remote
+
+import com.example.selliaapp.data.model.Invoice
+import com.example.selliaapp.data.model.InvoiceItem
+import com.google.firebase.firestore.DocumentSnapshot
+
+/**
+ * Mappers para representar facturas en Firestore.
+ */
+object InvoiceFirestoreMappers {
+    fun toMap(invoice: Invoice, number: String, items: List<InvoiceItem>): Map<String, Any?> = mapOf(
+        "id" to invoice.id,
+        "number" to number,
+        "dateMillis" to invoice.dateMillis,
+        "customerId" to invoice.customerId,
+        "customerName" to invoice.customerName,
+        "subtotal" to invoice.subtotal,
+        "taxes" to invoice.taxes,
+        "discountPercent" to invoice.discountPercent,
+        "discountAmount" to invoice.discountAmount,
+        "surchargePercent" to invoice.surchargePercent,
+        "surchargeAmount" to invoice.surchargeAmount,
+        "total" to invoice.total,
+        "paymentMethod" to invoice.paymentMethod,
+        "paymentNotes" to invoice.paymentNotes,
+        "items" to items.map { item ->
+            mapOf(
+                "id" to item.id,
+                "productId" to item.productId,
+                "productName" to item.productName,
+                "quantity" to item.quantity,
+                "unitPrice" to item.unitPrice,
+                "lineTotal" to item.lineTotal
+            )
+        }
+    )
+
+    data class RemoteInvoice(val invoice: Invoice, val items: List<InvoiceItem>)
+
+    fun fromDocument(doc: DocumentSnapshot): RemoteInvoice? {
+        val data = doc.data ?: return null
+        val invoiceId = doc.id.toLongOrNull()
+            ?: (data["id"] as? Number)?.toLong()
+            ?: return null
+
+        val dateMillis = (data["dateMillis"] as? Number)?.toLong() ?: return null
+
+        val invoice = Invoice(
+            id = invoiceId,
+            dateMillis = dateMillis,
+            customerId = (data["customerId"] as? Number)?.toInt(),
+            customerName = data["customerName"] as? String,
+            subtotal = (data["subtotal"] as? Number)?.toDouble() ?: 0.0,
+            taxes = (data["taxes"] as? Number)?.toDouble() ?: 0.0,
+            discountPercent = (data["discountPercent"] as? Number)?.toInt() ?: 0,
+            discountAmount = (data["discountAmount"] as? Number)?.toDouble() ?: 0.0,
+            surchargePercent = (data["surchargePercent"] as? Number)?.toInt() ?: 0,
+            surchargeAmount = (data["surchargeAmount"] as? Number)?.toDouble() ?: 0.0,
+            total = (data["total"] as? Number)?.toDouble() ?: 0.0,
+            paymentMethod = (data["paymentMethod"] as? String).orEmpty(),
+            paymentNotes = data["paymentNotes"] as? String
+        )
+
+        val itemsRaw = data["items"] as? List<*>
+        val items = itemsRaw
+            ?.mapNotNull { raw ->
+                val map = raw as? Map<*, *> ?: return@mapNotNull null
+                val productId = (map["productId"] as? Number)?.toInt() ?: return@mapNotNull null
+                val quantity = (map["quantity"] as? Number)?.toInt() ?: return@mapNotNull null
+                val unitPrice = (map["unitPrice"] as? Number)?.toDouble() ?: 0.0
+                InvoiceItem(
+                    id = (map["id"] as? Number)?.toLong() ?: 0L,
+                    invoiceId = invoiceId,
+                    productId = productId,
+                    productName = (map["productName"] as? String).orEmpty(),
+                    quantity = quantity,
+                    unitPrice = unitPrice,
+                    lineTotal = (map["lineTotal"] as? Number)?.toDouble() ?: unitPrice * quantity
+                )
+            }
+            ?: emptyList()
+
+        return RemoteInvoice(invoice, items)
+    }
+}

--- a/app/src/main/java/com/example/selliaapp/di/AppModule.kt
+++ b/app/src/main/java/com/example/selliaapp/di/AppModule.kt
@@ -24,6 +24,7 @@ import com.example.selliaapp.data.dao.ProductDao
 import com.example.selliaapp.data.dao.ProviderDao
 import com.example.selliaapp.data.dao.ProviderInvoiceDao
 import com.example.selliaapp.data.dao.ReportDataDao
+import com.example.selliaapp.data.dao.SyncOutboxDao
 import com.example.selliaapp.data.dao.UserDao
 import com.example.selliaapp.repository.CustomerRepository
 import com.example.selliaapp.repository.ExpenseRepository
@@ -82,6 +83,7 @@ object AppModule {
     @Provides fun provideCustomerDao(db: AppDatabase): CustomerDao = db.customerDao()
     @Provides fun provideInvoiceDao(db: AppDatabase): InvoiceDao = db.invoiceDao()
     @Provides fun provideInvoiceItemDao(db: AppDatabase): InvoiceItemDao = db.invoiceItemDao()
+    @Provides fun provideSyncOutboxDao(db: AppDatabase): SyncOutboxDao = db.syncOutboxDao()
     @Provides fun provideReportDataDao(db: AppDatabase): ReportDataDao = db.reportDataDao()
 
 

--- a/app/src/main/java/com/example/selliaapp/repository/FakeProductRepository.kt
+++ b/app/src/main/java/com/example/selliaapp/repository/FakeProductRepository.kt
@@ -51,12 +51,18 @@ class FakeProductRepository : IProductRepository {
         flowOf(PagingData.empty())
 
     override fun getProducts(): Flow<List<ProductEntity>> = productsFlow
+    override fun observeStockMovements(productId: Int, limit: Int): Flow<List<com.example.selliaapp.data.model.stock.StockMovementWithProduct>> =
+        flowOf(emptyList())
+
+    override fun observeRecentStockMovements(limit: Int): Flow<List<com.example.selliaapp.data.model.stock.StockMovementWithProduct>> =
+        flowOf(emptyList())
 
     // ---------- Cache util ----------
     override suspend fun cachedOrEmpty(): List<ProductEntity> = emptyList()
 
     // ---------- Stock ----------
     override suspend fun increaseStockByBarcode(barcode: String, delta: Int): Boolean = false
+    override suspend fun adjustStock(productId: Int, delta: Int, reason: String, note: String?): Boolean = false
 
     // ---------- Archivo tabular: filas parseadas ----------
     override suspend fun bulkUpsert(rows: List<ProductCsvImporter.Row>) {}

--- a/app/src/main/java/com/example/selliaapp/repository/IProductRepository.kt
+++ b/app/src/main/java/com/example/selliaapp/repository/IProductRepository.kt
@@ -9,6 +9,7 @@ import com.example.selliaapp.data.csv.ProductCsvImporter
 import com.example.selliaapp.data.local.entity.ProductEntity
 import com.example.selliaapp.data.model.ImportResult
 import com.example.selliaapp.data.model.Product
+import com.example.selliaapp.data.model.stock.StockMovementWithProduct
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -40,12 +41,15 @@ interface IProductRepository {
     // ---------- Paging ----------
     fun pagingSearchFlow(query: String): Flow<PagingData<ProductEntity>>
     fun getProducts(): Flow<List<ProductEntity>>
+    fun observeStockMovements(productId: Int, limit: Int = 20): Flow<List<StockMovementWithProduct>>
+    fun observeRecentStockMovements(limit: Int = 50): Flow<List<StockMovementWithProduct>>
 
     // ---------- Cache util ----------
     suspend fun cachedOrEmpty(): List<ProductEntity>
 
     // ---------- Stock ----------
     suspend fun increaseStockByBarcode(barcode: String, delta: Int): Boolean
+    suspend fun adjustStock(productId: Int, delta: Int, reason: String, note: String? = null): Boolean
 
     // ---------- Archivo tabular: filas parseadas ----------
     suspend fun bulkUpsert(rows: List<ProductCsvImporter.Row>)

--- a/app/src/main/java/com/example/selliaapp/repository/impl/IProductRepositoryAdapter.kt
+++ b/app/src/main/java/com/example/selliaapp/repository/impl/IProductRepositoryAdapter.kt
@@ -9,6 +9,7 @@ import com.example.selliaapp.data.csv.ProductCsvImporter
 import com.example.selliaapp.data.local.entity.ProductEntity
 import com.example.selliaapp.data.model.ImportResult
 import com.example.selliaapp.data.model.Product
+import com.example.selliaapp.data.model.stock.StockMovementWithProduct
 import com.example.selliaapp.repository.IProductRepository
 import com.example.selliaapp.repository.ProductRepository // <-- TU clase concreta existente
 import kotlinx.coroutines.flow.Flow
@@ -46,6 +47,13 @@ class IProductRepositoryAdapter @Inject constructor(
         legacy.pagingSearchFlow(query)
 
     override fun getProducts(): Flow<List<ProductEntity>> = legacy.getProducts()
+    override fun observeStockMovements(
+        productId: Int,
+        limit: Int
+    ): Flow<List<StockMovementWithProduct>> = legacy.observeStockMovements(productId, limit)
+
+    override fun observeRecentStockMovements(limit: Int): Flow<List<StockMovementWithProduct>> =
+        legacy.observeRecentStockMovements(limit)
 
     // ---------- Cache util ----------
     override suspend fun cachedOrEmpty(): List<ProductEntity> = legacy.cachedOrEmpty()
@@ -53,6 +61,13 @@ class IProductRepositoryAdapter @Inject constructor(
     // ---------- Stock ----------
     override suspend fun increaseStockByBarcode(barcode: String, delta: Int): Boolean =
         legacy.increaseStockByBarcode(barcode, delta)
+
+    override suspend fun adjustStock(
+        productId: Int,
+        delta: Int,
+        reason: String,
+        note: String?
+    ): Boolean = legacy.adjustStock(productId, delta, reason, note)
 
     // ---------- Archivo tabular: filas parseadas ----------
     override suspend fun bulkUpsert(rows: List<ProductCsvImporter.Row>) =

--- a/app/src/main/java/com/example/selliaapp/repository/impl/InvoiceRepositoryImpl.kt
+++ b/app/src/main/java/com/example/selliaapp/repository/impl/InvoiceRepositoryImpl.kt
@@ -1,12 +1,15 @@
- package com.example.selliaapp.repository.impl
+package com.example.selliaapp.repository.impl
 
- import androidx.room.withTransaction // <-- IMPORTANTE: withTransaction suspend de Room KTX
- import com.example.selliaapp.data.AppDatabase
+import androidx.room.withTransaction // <-- IMPORTANTE: withTransaction suspend de Room KTX
+import com.example.selliaapp.data.AppDatabase
 import com.example.selliaapp.data.dao.CustomerDao
 import com.example.selliaapp.data.dao.InvoiceDao
 import com.example.selliaapp.data.dao.InvoiceWithItems
 import com.example.selliaapp.data.dao.ProductDao
- import com.example.selliaapp.data.local.entity.StockMovementEntity
+import com.example.selliaapp.data.local.entity.ProductEntity
+import com.example.selliaapp.data.local.entity.StockMovementEntity
+import com.example.selliaapp.data.local.entity.SyncEntityType
+import com.example.selliaapp.data.local.entity.SyncOutboxEntity
 import com.example.selliaapp.data.model.Invoice
 import com.example.selliaapp.data.model.InvoiceItem
 import com.example.selliaapp.data.model.dashboard.DailySalesPoint
@@ -15,11 +18,16 @@ import com.example.selliaapp.data.model.sales.InvoiceDraft
 import com.example.selliaapp.data.model.sales.InvoiceItemRow
 import com.example.selliaapp.data.model.sales.InvoiceResult
 import com.example.selliaapp.data.model.sales.InvoiceSummary
+import com.example.selliaapp.data.remote.InvoiceFirestoreMappers
+import com.example.selliaapp.data.remote.ProductFirestoreMappers
 import com.example.selliaapp.di.IoDispatcher
 import com.example.selliaapp.repository.InvoiceRepository
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import java.time.Instant
 import java.time.LocalDate
@@ -27,82 +35,236 @@ import java.time.ZoneId
 import javax.inject.Inject
 import javax.inject.Singleton
 
- @Singleton
- class InvoiceRepositoryImpl @Inject constructor(
-     private val db: AppDatabase,
-     private val invoiceDao: InvoiceDao,
-     private val productDao: ProductDao,
-     private val customerDao: CustomerDao,
-     @IoDispatcher private val io: CoroutineDispatcher
- ) : InvoiceRepository {
+@Singleton
+class InvoiceRepositoryImpl @Inject constructor(
+    private val db: AppDatabase,
+    private val invoiceDao: InvoiceDao,
+    private val productDao: ProductDao,
+    private val customerDao: CustomerDao,
+    private val firestore: FirebaseFirestore,
+    @IoDispatcher private val io: CoroutineDispatcher
+) : InvoiceRepository {
+
+    private val invoicesCollection = firestore.collection("invoices")
+    private val productsCollection = firestore.collection("products")
+    private val syncOutboxDao = db.syncOutboxDao()
 
      // ----------------------------
      // Escritura principal
      // ----------------------------
-     override suspend fun confirmInvoice(draft: InvoiceDraft): InvoiceResult = withContext(io) {
-         val now = System.currentTimeMillis()
-         val number = "A-" + now.toString().takeLast(6)
+    override suspend fun confirmInvoice(draft: InvoiceDraft): InvoiceResult = withContext(io) {
+        val now = System.currentTimeMillis()
+        val resolvedCustomerName = draft.customerName
+            ?: draft.customerId?.toInt()?.let { customerDao.getNameById(it) }
 
-         db.withTransaction  {
-             // 1) Insert invoice
-             val invId = invoiceDao.insertInvoice(
-                 Invoice(
-                     id = 0L,
-                     dateMillis = now,
-                     customerId = draft.customerId?.toInt(),
-                     customerName = draft.customerName,
-                     total = draft.total
-                 )
-             )
+        var persistedInvoice: Invoice? = null
+        var persistedItems: List<InvoiceItem> = emptyList()
+        val touchedProducts = mutableSetOf<Int>()
 
-             // 2) Insert items
-             val items = draft.items.map { li ->
-                 InvoiceItem(
-                     id = 0L,
-                     invoiceId = invId,
-                     productId = li.productId.toInt(),
-                     productName = li.name,
-                     quantity = li.quantity,
-                     unitPrice = li.unitPrice,
-                     lineTotal = li.quantity * li.unitPrice
-                 )
-             }
-             invoiceDao.insertItems(items)
+        db.withTransaction {
+            val baseInvoice = Invoice(
+                id = 0L,
+                dateMillis = now,
+                customerId = draft.customerId?.toInt(),
+                customerName = resolvedCustomerName,
+                subtotal = draft.subtotal,
+                taxes = draft.taxes,
+                discountPercent = draft.discountPercent,
+                discountAmount = draft.discountAmount,
+                surchargePercent = draft.surchargePercent,
+                surchargeAmount = draft.surchargeAmount,
+                total = draft.total,
+                paymentMethod = draft.paymentMethod.ifBlank { "EFECTIVO" },
+                paymentNotes = draft.paymentNotes
+            )
+            val invId = invoiceDao.insertInvoice(baseInvoice)
 
-             // 3) Descontar stock y auditar movimiento (SALE)
-             val movementDao = db.stockMovementDao()
-             for (it in items) {
-                 val affected = productDao.decrementStockIfEnough(
-                     productId = it.productId,
-                     qty = it.quantity
-                 )
-                 // Si querés que falle la venta cuando no hay stock suficiente:
-                 require(affected == 1) { "Stock insuficiente o producto inexistente (id=${it.productId})" }
+            persistedItems = draft.items.map { li ->
+                InvoiceItem(
+                    id = 0L,
+                    invoiceId = invId,
+                    productId = li.productId.toInt(),
+                    productName = li.name,
+                    quantity = li.quantity,
+                    unitPrice = li.unitPrice,
+                    lineTotal = li.quantity * li.unitPrice
+                )
+            }
+            invoiceDao.insertItems(persistedItems)
 
-                 movementDao.insert(
-                     StockMovementEntity(
-                         productId = it.productId,
-                         delta = -it.quantity,
-                         reason = "SALE",
-                         ts = Instant.ofEpochMilli(now),
-                         user = null
-                     )
-                 )
-             }
-         }
+            val movementDao = db.stockMovementDao()
+            for (item in persistedItems) {
+                val affected = productDao.decrementStockIfEnough(
+                    productId = item.productId,
+                    qty = item.quantity
+                )
+                require(affected == 1) { "Stock insuficiente o producto inexistente (id=${item.productId})" }
 
-         InvoiceResult(invoiceId = now, invoiceNumber = number)
-     }
+                movementDao.insert(
+                    StockMovementEntity(
+                        productId = item.productId,
+                        delta = -item.quantity,
+                        reason = "SALE",
+                        ts = Instant.ofEpochMilli(now),
+                        user = null
+                    )
+                )
+                touchedProducts += item.productId
+            }
+
+            persistedInvoice = baseInvoice.copy(id = invId)
+            syncOutboxDao.upsert(
+                SyncOutboxEntity(
+                    entityType = SyncEntityType.INVOICE.storageKey,
+                    entityId = invId,
+                    createdAt = now
+                )
+            )
+            if (touchedProducts.isNotEmpty()) {
+                val entries = touchedProducts.map { productId ->
+                    SyncOutboxEntity(
+                        entityType = SyncEntityType.PRODUCT.storageKey,
+                        entityId = productId.toLong(),
+                        createdAt = now
+                    )
+                }
+                syncOutboxDao.upsertAll(entries)
+            }
+        }
+
+        val invoice = requireNotNull(persistedInvoice) { "No se pudo persistir la venta" }
+        val invoiceNumber = formatNumber(invoice.id)
+        val productsToSync: List<ProductEntity> = if (touchedProducts.isEmpty()) {
+            emptyList()
+        } else {
+            productDao.getByIds(touchedProducts.toList())
+        }
+
+        val productIdsForOutbox = touchedProducts.map(Int::toLong)
+        try {
+            syncInvoiceWithFirestore(invoice, invoiceNumber, persistedItems, productsToSync)
+            syncOutboxDao.deleteByTypeAndIds(
+                SyncEntityType.INVOICE.storageKey,
+                listOf(invoice.id)
+            )
+            if (productIdsForOutbox.isNotEmpty()) {
+                syncOutboxDao.deleteByTypeAndIds(
+                    SyncEntityType.PRODUCT.storageKey,
+                    productIdsForOutbox
+                )
+            }
+        } catch (t: Throwable) {
+            val errorMsg = extractErrorMessage(t)
+            val timestamp = System.currentTimeMillis()
+            syncOutboxDao.markAttempt(
+                SyncEntityType.INVOICE.storageKey,
+                listOf(invoice.id),
+                timestamp,
+                errorMsg
+            )
+            if (productIdsForOutbox.isNotEmpty()) {
+                syncOutboxDao.markAttempt(
+                    SyncEntityType.PRODUCT.storageKey,
+                    productIdsForOutbox,
+                    timestamp,
+                    errorMsg
+                )
+            }
+            throw t
+        }
+
+        InvoiceResult(invoiceId = invoice.id, invoiceNumber = invoiceNumber)
+    }
 
      // Compat con VMs viejos: versión plana
      override suspend fun addInvoiceAndAdjustStock(invoice: Invoice, items: List<InvoiceItem>) = withContext(io) {
-         db.withTransaction  {
-             val invId = invoiceDao.insertInvoice(invoice.copy(id = 0L))
-             val itemsWithFk = items.map { it.copy(id = 0L, invoiceId = invId) }
-             invoiceDao.insertItems(itemsWithFk)
-             // [PENDIENTE] Ajuste de stock y última compra de cliente.
-         }
-     }
+        val now = if (invoice.dateMillis != 0L) invoice.dateMillis else System.currentTimeMillis()
+        var persistedInvoice: Invoice? = null
+        var itemsWithFk: List<InvoiceItem> = emptyList()
+        val touchedProducts = mutableSetOf<Int>()
+
+        db.withTransaction {
+            val invId = invoiceDao.insertInvoice(invoice.copy(id = 0L))
+            itemsWithFk = items.map { it.copy(id = 0L, invoiceId = invId) }
+            invoiceDao.insertItems(itemsWithFk)
+
+            val movementDao = db.stockMovementDao()
+            for (item in itemsWithFk) {
+                val affected = productDao.decrementStockIfEnough(item.productId, item.quantity)
+                require(affected == 1) { "Stock insuficiente o producto inexistente (id=${item.productId})" }
+                movementDao.insert(
+                    StockMovementEntity(
+                        productId = item.productId,
+                        delta = -item.quantity,
+                        reason = "SALE",
+                        ts = Instant.ofEpochMilli(now),
+                        user = null
+                    )
+                )
+                touchedProducts += item.productId
+            }
+
+            persistedInvoice = invoice.copy(id = invId)
+            syncOutboxDao.upsert(
+                SyncOutboxEntity(
+                    entityType = SyncEntityType.INVOICE.storageKey,
+                    entityId = invId,
+                    createdAt = now
+                )
+            )
+            if (touchedProducts.isNotEmpty()) {
+                val entries = touchedProducts.map { productId ->
+                    SyncOutboxEntity(
+                        entityType = SyncEntityType.PRODUCT.storageKey,
+                        entityId = productId.toLong(),
+                        createdAt = now
+                    )
+                }
+                syncOutboxDao.upsertAll(entries)
+            }
+        }
+
+        val savedInvoice = requireNotNull(persistedInvoice)
+        val invoiceNumber = formatNumber(savedInvoice.id)
+        val productsToSync: List<ProductEntity> = if (touchedProducts.isEmpty()) {
+            emptyList()
+        } else {
+            productDao.getByIds(touchedProducts.toList())
+        }
+
+        val productIdsForOutbox = touchedProducts.map(Int::toLong)
+        try {
+            syncInvoiceWithFirestore(savedInvoice, invoiceNumber, itemsWithFk, productsToSync)
+            syncOutboxDao.deleteByTypeAndIds(
+                SyncEntityType.INVOICE.storageKey,
+                listOf(savedInvoice.id)
+            )
+            if (productIdsForOutbox.isNotEmpty()) {
+                syncOutboxDao.deleteByTypeAndIds(
+                    SyncEntityType.PRODUCT.storageKey,
+                    productIdsForOutbox
+                )
+            }
+        } catch (t: Throwable) {
+            val errorMsg = extractErrorMessage(t)
+            val timestamp = System.currentTimeMillis()
+            syncOutboxDao.markAttempt(
+                SyncEntityType.INVOICE.storageKey,
+                listOf(savedInvoice.id),
+                timestamp,
+                errorMsg
+            )
+            if (productIdsForOutbox.isNotEmpty()) {
+                syncOutboxDao.markAttempt(
+                    SyncEntityType.PRODUCT.storageKey,
+                    productIdsForOutbox,
+                    timestamp,
+                    errorMsg
+                )
+            }
+            throw t
+        }
+    }
 
      // ----------------------------
      // Lecturas
@@ -180,30 +342,55 @@ import javax.inject.Singleton
          )
      }
 
-     private fun mapToDetail(rel: InvoiceWithItems): InvoiceDetail {
-         val inv = rel.invoice
-         val itemsUi = rel.items.map {
-             InvoiceItemRow(
-                 productId = (it.productId ?: 0).toLong(),    // ajustá si tu entity usa Int?
-                 name = it.productName ?: "(s/n)",
-                 quantity = it.quantity,
-                 unitPrice = it.unitPrice
-             )
-         }
-         val ld = Instant.ofEpochMilli(inv.dateMillis).atZone(ZoneId.systemDefault()).toLocalDate()
-         return InvoiceDetail(
-             id = inv.id,
-             number = formatNumber(inv.id),
-             customerName = inv.customerName ?: "Consumidor Final",
-             date = ld,
-             total = inv.total,
-             items = itemsUi,
-             notes = null
-         )
-     }
+    private fun mapToDetail(rel: InvoiceWithItems): InvoiceDetail {
+        val inv = rel.invoice
+        val itemsUi = rel.items.map {
+            InvoiceItemRow(
+                productId = (it.productId ?: 0).toLong(),    // ajustá si tu entity usa Int?
+                name = it.productName ?: "(s/n)",
+                quantity = it.quantity,
+                unitPrice = it.unitPrice
+            )
+        }
+        val ld = Instant.ofEpochMilli(inv.dateMillis).atZone(ZoneId.systemDefault()).toLocalDate()
+        return InvoiceDetail(
+            id = inv.id,
+            number = formatNumber(inv.id),
+            customerName = inv.customerName ?: "Consumidor Final",
+            date = ld,
+            total = inv.total,
+            items = itemsUi,
+            notes = inv.paymentNotes
+        )
+    }
 
-     private fun formatNumber(id: Long): String =
-         "F-" + id.toString().padStart(8, '0')
+    private fun formatNumber(id: Long): String =
+        "F-" + id.toString().padStart(8, '0')
+
+    private fun extractErrorMessage(t: Throwable): String =
+        t.message?.take(512) ?: t::class.java.simpleName
+
+    private suspend fun syncInvoiceWithFirestore(
+        invoice: Invoice,
+        number: String,
+        items: List<InvoiceItem>,
+        products: List<ProductEntity>
+    ) {
+        invoicesCollection
+            .document(invoice.id.toString())
+            .set(InvoiceFirestoreMappers.toMap(invoice, number, items))
+            .await()
+
+        if (products.isEmpty()) return
+
+        val batch = firestore.batch()
+        products.forEach { product ->
+            if (product.id == 0) return@forEach
+            val doc = productsCollection.document(product.id.toString())
+            batch.set(doc, ProductFirestoreMappers.toMap(product), SetOptions.merge())
+        }
+        batch.commit().await()
+    }
 
 
      override fun observeAll(): Flow<List<InvoiceSummary>> =

--- a/app/src/main/java/com/example/selliaapp/repository/impl/InvoiceRepositoryImpl.kt
+++ b/app/src/main/java/com/example/selliaapp/repository/impl/InvoiceRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.example.selliaapp.data.dao.InvoiceWithItems
 import com.example.selliaapp.data.dao.ProductDao
 import com.example.selliaapp.data.local.entity.ProductEntity
 import com.example.selliaapp.data.local.entity.StockMovementEntity
+import com.example.selliaapp.data.model.stock.StockMovementReasons
 import com.example.selliaapp.data.local.entity.SyncEntityType
 import com.example.selliaapp.data.local.entity.SyncOutboxEntity
 import com.example.selliaapp.data.model.Invoice
@@ -100,15 +101,15 @@ class InvoiceRepositoryImpl @Inject constructor(
                 )
                 require(affected == 1) { "Stock insuficiente o producto inexistente (id=${item.productId})" }
 
-                movementDao.insert(
-                    StockMovementEntity(
-                        productId = item.productId,
-                        delta = -item.quantity,
-                        reason = "SALE",
-                        ts = Instant.ofEpochMilli(now),
-                        user = null
+                    movementDao.insert(
+                        StockMovementEntity(
+                            productId = item.productId,
+                            delta = -item.quantity,
+                            reason = StockMovementReasons.SALE,
+                            ts = Instant.ofEpochMilli(now),
+                            user = null
+                        )
                     )
-                )
                 touchedProducts += item.productId
             }
 
@@ -192,15 +193,15 @@ class InvoiceRepositoryImpl @Inject constructor(
             for (item in itemsWithFk) {
                 val affected = productDao.decrementStockIfEnough(item.productId, item.quantity)
                 require(affected == 1) { "Stock insuficiente o producto inexistente (id=${item.productId})" }
-                movementDao.insert(
-                    StockMovementEntity(
-                        productId = item.productId,
-                        delta = -item.quantity,
-                        reason = "SALE",
-                        ts = Instant.ofEpochMilli(now),
-                        user = null
+                    movementDao.insert(
+                        StockMovementEntity(
+                            productId = item.productId,
+                            delta = -item.quantity,
+                            reason = StockMovementReasons.SALE,
+                            ts = Instant.ofEpochMilli(now),
+                            user = null
+                        )
                     )
-                )
                 touchedProducts += item.productId
             }
 

--- a/app/src/main/java/com/example/selliaapp/sync/SyncRepositoryImpl.kt
+++ b/app/src/main/java/com/example/selliaapp/sync/SyncRepositoryImpl.kt
@@ -1,14 +1,155 @@
-
 package com.example.selliaapp.sync
 
-/* [NUEVO] Implementación base sin dependencias (placeholder). Inyectá DAOs/APIs reales luego. */
+import com.example.selliaapp.data.AppDatabase
+import com.example.selliaapp.data.dao.InvoiceDao
+import com.example.selliaapp.data.dao.InvoiceItemDao
+import com.example.selliaapp.data.dao.ProductDao
+import com.example.selliaapp.data.dao.SyncOutboxDao
+import com.example.selliaapp.data.local.entity.SyncEntityType
+import com.example.selliaapp.data.remote.InvoiceFirestoreMappers
+import com.example.selliaapp.data.remote.ProductFirestoreMappers
+import com.example.selliaapp.di.AppModule.IoDispatcher
+import com.example.selliaapp.repository.ProductRepository
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.SetOptions
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class SyncRepositoryImpl @Inject constructor(
-    // TODO: DAOs/APIs reales acá, p.ej. private val productDao: ProductDao, private val api: SelliaApi
+    private val db: AppDatabase,
+    private val productDao: ProductDao,
+    private val invoiceDao: InvoiceDao,
+    private val invoiceItemDao: InvoiceItemDao,
+    private val syncOutboxDao: SyncOutboxDao,
+    private val productRepository: ProductRepository,
+    private val firestore: FirebaseFirestore,
+    @IoDispatcher private val io: CoroutineDispatcher
 ) : SyncRepository {
-    override suspend fun pushPending() { /* TODO subir pendientes */ }
-    override suspend fun pullRemote() { /* TODO bajar/aplicar cambios */ }
+
+    private val productsCollection = firestore.collection("products")
+    private val invoicesCollection = firestore.collection("invoices")
+
+    override suspend fun pushPending() = withContext(io) {
+        val now = System.currentTimeMillis()
+        pushPendingProducts(now)
+        pushPendingInvoices(now)
+    }
+
+    override suspend fun pullRemote() = withContext(io) {
+        productRepository.syncDown()
+
+        val snapshot = invoicesCollection.get().await()
+        if (snapshot.isEmpty) return@withContext
+
+        val remoteInvoices = snapshot.documents.mapNotNull { doc ->
+            InvoiceFirestoreMappers.fromDocument(doc)
+        }
+
+        if (remoteInvoices.isEmpty()) return@withContext
+
+        db.withTransaction {
+            remoteInvoices.forEach { remote ->
+                val invoice = remote.invoice
+                invoiceDao.insertInvoice(invoice)
+                invoiceItemDao.deleteByInvoiceId(invoice.id)
+                if (remote.items.isNotEmpty()) {
+                    invoiceItemDao.insertAll(remote.items)
+                }
+            }
+        }
+    }
+
+    private suspend fun pushPendingProducts(now: Long) {
+        val pending = syncOutboxDao.getByType(SyncEntityType.PRODUCT.storageKey)
+        if (pending.isEmpty()) return
+
+        val ids = pending.map { it.entityId.toInt() }
+        val entities = productDao.getByIds(ids)
+        val foundIds = entities.map { it.id.toLong() }.toSet()
+        val missing = pending.map { it.entityId }.filterNot { it in foundIds }
+        if (missing.isNotEmpty()) {
+            syncOutboxDao.deleteByTypeAndIds(SyncEntityType.PRODUCT.storageKey, missing)
+        }
+        if (entities.isEmpty()) return
+
+        val batch = firestore.batch()
+        entities.forEach { product ->
+            if (product.id == 0) return@forEach
+            val doc = productsCollection.document(product.id.toString())
+            batch.set(doc, ProductFirestoreMappers.toMap(product), SetOptions.merge())
+        }
+
+        try {
+            batch.commit().await()
+            syncOutboxDao.deleteByTypeAndIds(
+                SyncEntityType.PRODUCT.storageKey,
+                entities.map { it.id.toLong() }
+            )
+        } catch (t: Throwable) {
+            val error = extractErrorMessage(t)
+            syncOutboxDao.markAttempt(
+                SyncEntityType.PRODUCT.storageKey,
+                entities.map { it.id.toLong() },
+                now,
+                error
+            )
+            throw t
+        }
+    }
+
+    private suspend fun pushPendingInvoices(now: Long) {
+        val pending = syncOutboxDao.getByType(SyncEntityType.INVOICE.storageKey)
+        if (pending.isEmpty()) return
+
+        val ids = pending.map { it.entityId }
+        val relations = invoiceDao.getInvoicesWithItemsByIds(ids)
+        val foundIds = relations.map { it.invoice.id }.toSet()
+        val missing = ids.filterNot { it in foundIds }
+        if (missing.isNotEmpty()) {
+            syncOutboxDao.deleteByTypeAndIds(SyncEntityType.INVOICE.storageKey, missing)
+        }
+        if (relations.isEmpty()) return
+
+        val batch = firestore.batch()
+        relations.forEach { relation ->
+            val invoice = relation.invoice
+            val doc = invoicesCollection.document(invoice.id.toString())
+            batch.set(
+                doc,
+                InvoiceFirestoreMappers.toMap(
+                    invoice,
+                    formatInvoiceNumber(invoice.id),
+                    relation.items
+                ),
+                SetOptions.merge()
+            )
+        }
+
+        try {
+            batch.commit().await()
+            syncOutboxDao.deleteByTypeAndIds(
+                SyncEntityType.INVOICE.storageKey,
+                relations.map { it.invoice.id }
+            )
+        } catch (t: Throwable) {
+            val error = extractErrorMessage(t)
+            syncOutboxDao.markAttempt(
+                SyncEntityType.INVOICE.storageKey,
+                relations.map { it.invoice.id },
+                now,
+                error
+            )
+            throw t
+        }
+    }
+
+    private fun formatInvoiceNumber(id: Long): String =
+        "F-" + id.toString().padStart(8, '0')
+
+    private fun extractErrorMessage(t: Throwable): String =
+        t.message?.take(512) ?: t::class.java.simpleName
 }

--- a/app/src/main/java/com/example/selliaapp/ui/navigation/Routes.kt
+++ b/app/src/main/java/com/example/selliaapp/ui/navigation/Routes.kt
@@ -12,6 +12,17 @@ sealed class Routes(val route: String) {
     object Sell : Routes("sell")
     object Stock : Routes("stock")
     object Stock_import : Routes("stock_import")
+    object QuickAdjustStock : Routes("stock/adjust/{productId}") {
+        const val ARG_PRODUCT_ID = "productId"
+        fun withProduct(productId: Int) = "stock/adjust/$productId"
+        val arguments = listOf(navArgument(ARG_PRODUCT_ID) { type = NavType.IntType })
+    }
+    object QuickReorder : Routes("stock/reorder/{productId}") {
+        const val ARG_PRODUCT_ID = "productId"
+        fun withProduct(productId: Int) = "stock/reorder/$productId"
+        val arguments = listOf(navArgument(ARG_PRODUCT_ID) { type = NavType.IntType })
+    }
+    object StockMovements : Routes("stock/movements")
 
     object Config : Routes("config")
     object Checkout : Routes("checkout")
@@ -34,7 +45,10 @@ sealed class Routes(val route: String) {
     object ProvidersHub : Routes("providers_hub")
     object ManageProviders : Routes("manage_providers")
     object ProviderInvoices : Routes("provider_invoices")              // listado por proveedor
-    object ProviderInvoiceDetail : Routes("provider_invoice_detail?invoiceId={invoiceId}")
+    object ProviderInvoiceDetail : Routes("provider_invoice_detail?invoiceId={invoiceId}") {
+        const val ARG_ID = "invoiceId"
+        fun build(id: Int) = "provider_invoice_detail?invoiceId=$id"
+    }
     object ProviderPayments : Routes("provider_payments")              // pendientes
 
     // ---------- NUEVO: Gastos ----------
@@ -131,6 +145,8 @@ sealed class Routes(val route: String) {
                 defaultValue = null
             }
         )
+        val quickAdjustArgs = Routes.QuickAdjustStock.arguments
+        val quickReorderArgs = Routes.QuickReorder.arguments
     }
 
 }

--- a/app/src/main/java/com/example/selliaapp/ui/navigation/SelliaApp.kt
+++ b/app/src/main/java/com/example/selliaapp/ui/navigation/SelliaApp.kt
@@ -45,6 +45,7 @@ import com.example.selliaapp.ui.screens.manage.SyncScreen
 import com.example.selliaapp.ui.screens.providers.ManageProvidersScreen
 import com.example.selliaapp.ui.screens.providers.ProviderInvoiceDetailScreen
 import com.example.selliaapp.ui.screens.providers.ProviderInvoicesScreen
+import com.example.selliaapp.sync.SyncScheduler
 import com.example.selliaapp.ui.screens.providers.ProviderPaymentsScreen
 import com.example.selliaapp.ui.screens.providers.ProvidersHubScreen
 import com.example.selliaapp.ui.screens.reports.ReportsScreen
@@ -106,8 +107,15 @@ fun SelliaApp(
                     onReports = { navController.navigate(Routes.Reports.route) },
                     onProviders = { navController.navigate(Routes.ProvidersHub.route) },   // NUEVO
                     onExpenses = { navController.navigate(Routes.ExpensesHub.route) },
+                    onSyncNow = { SyncScheduler.enqueueNow(context) },
+                    onAlertAdjustStock = { productId ->
+                        navController.navigate(Routes.AddProduct.withId(productId.toLong()))
+                    },
+                    onAlertCreatePurchase = {
+                        navController.navigate(Routes.ProviderInvoices.route)
+                    },
                     vm = homeVm,
-
+ 
                 )
             }
 

--- a/app/src/main/java/com/example/selliaapp/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/selliaapp/ui/screens/HomeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -59,7 +60,9 @@ fun HomeScreen(
     onReports: () -> Unit,
     onProviders: () -> Unit,          // NUEVO
     onExpenses: () -> Unit,
-    onSyncNow: () -> Unit = {}
+    onSyncNow: () -> Unit = {},
+    onAlertAdjustStock: (Int) -> Unit = {},
+    onAlertCreatePurchase: (Int) -> Unit = {}
     ) {
     val state by vm.state.collectAsState()
     val localeEsAr = Locale("es", "AR")
@@ -194,26 +197,44 @@ fun HomeScreen(
                             if (index > 0) {
                                 Divider()
                             }
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Column(modifier = Modifier.weight(1f)) {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 8.dp)
+                            ) {
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(
+                                            text = alert.name,
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
+                                        Text(
+                                            text = "Stock ${alert.quantity} / mínimo ${alert.minStock}",
+                                            style = MaterialTheme.typography.bodySmall,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                    Spacer(Modifier.width(12.dp))
                                     Text(
-                                        text = alert.name,
-                                        style = MaterialTheme.typography.bodyLarge,
-                                        maxLines = 1,
-                                        overflow = TextOverflow.Ellipsis
-                                    )
-                                    Text(
-                                        text = "Stock ${alert.quantity} / mínimo ${alert.minStock}",
-                                        style = MaterialTheme.typography.bodySmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        text = "Faltan ${alert.deficit}",
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        color = MaterialTheme.colorScheme.error
                                     )
                                 }
-                                Spacer(Modifier.width(12.dp))
-                                Text(
-                                    text = "Faltan ${alert.deficit}",
-                                    style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.error
-                                )
+                                Spacer(Modifier.height(8.dp))
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                ) {
+                                    TextButton(onClick = { onAlertAdjustStock(alert.id) }) {
+                                        Text("Ajustar stock")
+                                    }
+                                    TextButton(onClick = { onAlertCreatePurchase(alert.id) }) {
+                                        Text("Crear orden")
+                                    }
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/example/selliaapp/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/example/selliaapp/ui/screens/HomeScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.Business
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.InsertChart
 import androidx.compose.material.icons.filled.PointOfSale
 import androidx.compose.material.icons.filled.Warning
@@ -61,6 +62,7 @@ fun HomeScreen(
     onProviders: () -> Unit,          // NUEVO
     onExpenses: () -> Unit,
     onSyncNow: () -> Unit = {},
+    onViewStockMovements: () -> Unit = {},
     onAlertAdjustStock: (Int) -> Unit = {},
     onAlertCreatePurchase: (Int) -> Unit = {}
     ) {
@@ -162,6 +164,10 @@ fun HomeScreen(
                     OutlinedButton(onClick = onSyncNow, modifier = Modifier.weight(1f)) {
                         Icon(Icons.Default.Sync, contentDescription = null)
                         Spacer(Modifier.width(8.dp)); Text("Sincronizar Ahora!")
+                    }
+                    OutlinedButton(onClick = onViewStockMovements, modifier = Modifier.weight(1f)) {
+                        Icon(Icons.Default.History, contentDescription = null)
+                        Spacer(Modifier.width(8.dp)); Text("Historial de stock")
                     }
                 }
             }

--- a/app/src/main/java/com/example/selliaapp/ui/screens/stock/QuickReorderScreen.kt
+++ b/app/src/main/java/com/example/selliaapp/ui/screens/stock/QuickReorderScreen.kt
@@ -1,0 +1,180 @@
+package com.example.selliaapp.ui.screens.stock
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenu
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import com.example.selliaapp.ui.components.BackTopAppBar
+import com.example.selliaapp.viewmodel.QuickReorderState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuickReorderScreen(
+    state: QuickReorderState,
+    onBack: () -> Unit,
+    onProviderSelected: (Int) -> Unit,
+    onQuantityChange: (String) -> Unit,
+    onUnitPriceChange: (String) -> Unit,
+    onToggleReceive: (Boolean) -> Unit,
+    onSubmit: () -> Unit
+) {
+    Scaffold(topBar = { BackTopAppBar(title = "Crear orden", onBack = onBack) }) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            val product = state.product
+            Text(
+                text = product?.name ?: "Producto no disponible",
+                style = MaterialTheme.typography.headlineSmall
+            )
+            if (product != null) {
+                Text(
+                    text = "Stock actual: ${product.quantity}  •  Mínimo: ${product.minStock ?: 0}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            var providerExpanded by remember { mutableStateOf(false) }
+            ExposedDropdownMenuBox(
+                expanded = providerExpanded,
+                onExpandedChange = { providerExpanded = it },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                val selectedProvider = state.providers.firstOrNull { it.id == state.selectedProviderId }
+                OutlinedTextField(
+                    value = selectedProvider?.name ?: "Seleccionar proveedor",
+                    onValueChange = {},
+                    readOnly = true,
+                    modifier = Modifier
+                        .menuAnchor()
+                        .fillMaxWidth(),
+                    label = { Text("Proveedor") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = providerExpanded) }
+                )
+                ExposedDropdownMenu(
+                    expanded = providerExpanded,
+                    onDismissRequest = { providerExpanded = false }
+                ) {
+                    state.providers.forEach { provider ->
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = { Text(provider.name) },
+                            onClick = {
+                                onProviderSelected(provider.id)
+                                providerExpanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            if (state.providers.isEmpty()) {
+                Text(
+                    text = "No hay proveedores disponibles. Agregá uno desde el módulo de proveedores.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            OutlinedTextField(
+                value = state.quantityText,
+                onValueChange = onQuantityChange,
+                label = { Text("Cantidad a ordenar") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+
+            OutlinedTextField(
+                value = state.unitPriceText,
+                onValueChange = onUnitPriceChange,
+                label = { Text("Precio unitario (con IVA)") },
+                modifier = Modifier.fillMaxWidth(),
+                singleLine = true
+            )
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Switch(
+                    checked = state.autoReceive,
+                    onCheckedChange = onToggleReceive,
+                    colors = SwitchDefaults.colors(checkedThumbColor = MaterialTheme.colorScheme.primary)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Actualizar stock inmediatamente")
+            }
+
+            Text(
+                text = "Total estimado: ${state.totalText}",
+                style = MaterialTheme.typography.titleMedium
+            )
+
+            if (state.error != null) {
+                Text(
+                    text = state.error,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+
+            if (state.isSaving) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    androidx.compose.material3.CircularProgressIndicator()
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Button(
+                    onClick = onSubmit,
+                    enabled = !state.isSaving && state.product != null,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Guardar orden")
+                }
+                OutlinedButton(
+                    onClick = onBack,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Cancelar")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/selliaapp/ui/screens/stock/QuickStockAdjustScreen.kt
+++ b/app/src/main/java/com/example/selliaapp/ui/screens/stock/QuickStockAdjustScreen.kt
@@ -1,0 +1,186 @@
+package com.example.selliaapp.ui.screens.stock
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.ExposedDropdownMenu
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.selliaapp.data.model.stock.StockAdjustmentReason
+import com.example.selliaapp.ui.components.BackTopAppBar
+import com.example.selliaapp.viewmodel.QuickAdjustUiState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun QuickStockAdjustScreen(
+    state: QuickAdjustUiState,
+    onBack: () -> Unit,
+    onDeltaChange: (String) -> Unit,
+    onReasonSelected: (StockAdjustmentReason) -> Unit,
+    onNoteChange: (String) -> Unit,
+    onSubmit: () -> Unit
+) {
+    Scaffold(topBar = { BackTopAppBar(title = "Ajustar stock", onBack = onBack) }) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            if (state.loading) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                }
+            }
+
+            val product = state.product
+            Text(
+                text = product?.name ?: "Producto no disponible",
+                style = MaterialTheme.typography.headlineSmall,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
+            if (product != null) {
+                Text(
+                    text = "Stock actual: ${product.quantity}  •  Mínimo: ${product.minStock ?: 0}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            OutlinedTextField(
+                value = state.deltaText,
+                onValueChange = onDeltaChange,
+                label = { Text("Cantidad a ajustar") },
+                keyboardOptions = KeyboardOptions.Default,
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+                supportingText = {
+                    Text("Valores positivos suman stock, negativos descuentan.")
+                }
+            )
+
+            var expanded by remember { mutableStateOf(false) }
+            val options = remember { StockAdjustmentReason.values().toList() }
+            ExposedDropdownMenuBox(
+                expanded = expanded,
+                onExpandedChange = { expanded = it },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedTextField(
+                    value = state.selectedReason.label,
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Motivo") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+                    modifier = Modifier
+                        .menuAnchor()
+                        .fillMaxWidth()
+                )
+                ExposedDropdownMenu(
+                    expanded = expanded,
+                    onDismissRequest = { expanded = false }
+                ) {
+                    options.forEach { option ->
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = { Text(option.label) },
+                            onClick = {
+                                onReasonSelected(option)
+                                expanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            OutlinedTextField(
+                value = state.note,
+                onValueChange = onNoteChange,
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Nota (opcional)") },
+                singleLine = false
+            )
+
+            if (state.error != null) {
+                Text(
+                    text = state.error,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodyMedium
+                )
+            }
+
+            if (state.isSaving) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                }
+            }
+
+            if (state.formattedMovements.isNotEmpty()) {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text(
+                        text = "Últimos movimientos",
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                    state.formattedMovements.forEach { item ->
+                        Text(
+                            text = item,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Button(
+                    onClick = onSubmit,
+                    enabled = !state.isSaving && state.product != null,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Registrar ajuste")
+                }
+                OutlinedButton(
+                    onClick = onBack,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text("Cancelar")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/selliaapp/ui/screens/stock/StockMovementsScreen.kt
+++ b/app/src/main/java/com/example/selliaapp/ui/screens/stock/StockMovementsScreen.kt
@@ -1,0 +1,131 @@
+package com.example.selliaapp.ui.screens.stock
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenu
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.selliaapp.data.model.stock.StockMovementReasons
+import com.example.selliaapp.ui.components.BackTopAppBar
+import com.example.selliaapp.viewmodel.StockMovementsUiState
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StockMovementsScreen(
+    state: StockMovementsUiState,
+    onBack: () -> Unit,
+    onFilterChange: (String?) -> Unit
+) {
+    val formatter = remember {
+        DateTimeFormatter.ofPattern("dd/MM HH:mm").withZone(ZoneId.systemDefault())
+    }
+    Scaffold(topBar = { BackTopAppBar(title = "Historial de stock", onBack = onBack) }) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            var filterExpanded by remember { mutableStateOf(false) }
+            val selectedLabel = state.selectedReason?.let { StockMovementReasons.humanReadable(it) }
+            val options = state.allReasons
+            ExposedDropdownMenuBox(
+                expanded = filterExpanded,
+                onExpandedChange = { filterExpanded = it },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedTextField(
+                    value = selectedLabel ?: "Todos los motivos",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Filtrar por motivo") },
+                    trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = filterExpanded) },
+                    modifier = Modifier
+                        .menuAnchor()
+                        .fillMaxWidth()
+                )
+                ExposedDropdownMenu(
+                    expanded = filterExpanded,
+                    onDismissRequest = { filterExpanded = false }
+                ) {
+                    androidx.compose.material3.DropdownMenuItem(
+                        text = { Text("Todos") },
+                        onClick = {
+                            onFilterChange(null)
+                            filterExpanded = false
+                        }
+                    )
+                    options.forEach { option ->
+                        val label = StockMovementReasons.humanReadable(option)
+                        androidx.compose.material3.DropdownMenuItem(
+                            text = { Text(label) },
+                            onClick = {
+                                onFilterChange(option)
+                                filterExpanded = false
+                            }
+                        )
+                    }
+                }
+            }
+
+            if (state.loading) {
+                Text("Cargando movimientos…", style = MaterialTheme.typography.bodyMedium)
+            } else if (state.movements.isEmpty()) {
+                Text(
+                    text = "No hay movimientos en el rango consultado.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    items(state.movements) { movement ->
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            Text(
+                                text = movement.productName,
+                                style = MaterialTheme.typography.titleSmall,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                            Text(
+                                text = buildString {
+                                    val delta = if (movement.delta >= 0) "+${movement.delta}" else movement.delta.toString()
+                                    append("$delta • ${StockMovementReasons.humanReadable(movement.reason)}")
+                                    movement.note?.takeIf { it.isNotBlank() }?.let { note ->
+                                        append(" • $note")
+                                    }
+                                },
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Text(
+                                text = formatter.format(movement.ts),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/selliaapp/viewmodel/QuickReorderViewModel.kt
+++ b/app/src/main/java/com/example/selliaapp/viewmodel/QuickReorderViewModel.kt
@@ -1,0 +1,200 @@
+package com.example.selliaapp.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.selliaapp.data.local.entity.ProductEntity
+import com.example.selliaapp.data.local.entity.ProviderEntity
+import com.example.selliaapp.data.model.ProviderInvoice
+import com.example.selliaapp.data.model.ProviderInvoiceItem
+import com.example.selliaapp.repository.IProductRepository
+import com.example.selliaapp.repository.ProviderInvoiceRepository
+import com.example.selliaapp.repository.ProviderRepository
+import com.example.selliaapp.ui.navigation.Routes
+import com.example.selliaapp.data.model.stock.StockMovementReasons
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.Locale
+import javax.inject.Inject
+import kotlin.math.roundToInt
+
+data class QuickReorderState(
+    val loading: Boolean = true,
+    val product: ProductEntity? = null,
+    val providers: List<ProviderEntity> = emptyList(),
+    val selectedProviderId: Int? = null,
+    val quantityText: String = "",
+    val unitPriceText: String = "",
+    val autoReceive: Boolean = false,
+    val isSaving: Boolean = false,
+    val error: String? = null,
+    val success: Boolean = false,
+    val createdInvoiceId: Int? = null
+) {
+    val totalText: String
+        get() = runCatching {
+            val qty = quantityText.toDouble()
+            val price = unitPriceText.replace(',', '.').toDouble()
+            String.format(Locale.getDefault(), "%.2f", qty * price)
+        }.getOrDefault("0.00")
+}
+
+@HiltViewModel
+class QuickReorderViewModel @Inject constructor(
+    private val productRepository: IProductRepository,
+    private val providerRepository: ProviderRepository,
+    private val providerInvoiceRepository: ProviderInvoiceRepository,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val productId: Int = checkNotNull(
+        savedStateHandle.get<Int>(Routes.QuickReorder.ARG_PRODUCT_ID)
+    )
+
+    private val _state = MutableStateFlow(QuickReorderState())
+    val state: StateFlow<QuickReorderState> = _state.asStateFlow()
+
+    init {
+        loadProduct()
+        observeProviders()
+    }
+
+    private fun loadProduct() {
+        viewModelScope.launch {
+            val product = productRepository.getById(productId)
+            val deficit = product?.let { p ->
+                val min = p.minStock ?: 0
+                val missing = (min - p.quantity).coerceAtLeast(0)
+                if (missing > 0) missing.toString() else ""
+            } ?: ""
+            val price = product?.let { p ->
+                val final = p.finalPrice ?: p.price ?: p.basePrice?.let { base ->
+                    val tax = p.taxRate ?: 0.0
+                    base * (1 + tax)
+                }
+                final?.let { String.format(Locale.getDefault(), "%.2f", it) } ?: ""
+            } ?: ""
+            _state.update {
+                it.copy(
+                    loading = false,
+                    product = product,
+                    quantityText = deficit,
+                    unitPriceText = price,
+                    selectedProviderId = product?.providerId,
+                    autoReceive = false,
+                    error = if (product == null) "Producto no encontrado" else null
+                )
+            }
+        }
+    }
+
+    private fun observeProviders() {
+        viewModelScope.launch {
+            providerRepository.observeAll().collect { providers ->
+                val current = state.value
+                val resolvedProviderId = when {
+                    current.selectedProviderId != null -> current.selectedProviderId
+                    current.product?.providerId != null -> current.product.providerId
+                    else -> providers.firstOrNull()?.id
+                }
+                _state.update {
+                    it.copy(providers = providers, selectedProviderId = resolvedProviderId)
+                }
+            }
+        }
+    }
+
+    fun onProviderSelected(id: Int) {
+        _state.update { it.copy(selectedProviderId = id) }
+    }
+
+    fun onQuantityChange(text: String) {
+        _state.update { it.copy(quantityText = text, error = null) }
+    }
+
+    fun onUnitPriceChange(text: String) {
+        _state.update { it.copy(unitPriceText = text, error = null) }
+    }
+
+    fun onToggleAutoReceive(value: Boolean) {
+        _state.update { it.copy(autoReceive = value) }
+    }
+
+    fun createOrder() {
+        val snapshot = state.value
+        val product = snapshot.product ?: run {
+            _state.update { it.copy(error = "Producto no encontrado") }
+            return
+        }
+        val providerId = snapshot.selectedProviderId ?: run {
+            _state.update { it.copy(error = "Seleccioná un proveedor") }
+            return
+        }
+        val quantity = snapshot.quantityText.toDoubleOrNull()?.takeIf { it > 0 } ?: run {
+            _state.update { it.copy(error = "Ingresá una cantidad mayor a cero") }
+            return
+        }
+        val unitPrice = snapshot.unitPriceText.replace(',', '.').toDoubleOrNull()?.takeIf { it > 0 } ?: run {
+            _state.update { it.copy(error = "Ingresá un precio válido") }
+            return
+        }
+        viewModelScope.launch {
+            _state.update { it.copy(isSaving = true, error = null, success = false, createdInvoiceId = null) }
+            val now = System.currentTimeMillis()
+            val taxRate = product.taxRate ?: 0.0
+            val priceUnitFinal = unitPrice
+            val priceUnitNet = if (taxRate > 0) priceUnitFinal / (1 + taxRate) else priceUnitFinal
+            val vatAmount = priceUnitNet * taxRate * quantity
+            val lineTotal = priceUnitFinal * quantity
+            val invoice = ProviderInvoice(
+                providerId = providerId,
+                number = "PO-$now",
+                issueDateMillis = now,
+                total = lineTotal
+            )
+            val item = ProviderInvoiceItem(
+                invoiceId = 0,
+                code = product.code,
+                name = product.name,
+                quantity = quantity,
+                priceUnit = priceUnitNet,
+                vatPercent = (taxRate * 100.0),
+                vatAmount = vatAmount,
+                total = lineTotal
+            )
+            try {
+                val invoiceId = providerInvoiceRepository.create(invoice, listOf(item)).toInt()
+                if (snapshot.autoReceive) {
+                    val delta = quantity.roundToInt()
+                    if (delta > 0) {
+                        productRepository.adjustStock(
+                            productId = product.id,
+                            delta = delta,
+                            reason = StockMovementReasons.QUICK_ORDER_RECEIVED,
+                            note = "Orden ${invoice.number}"
+                        )
+                    }
+                }
+                _state.update {
+                    it.copy(
+                        isSaving = false,
+                        success = true,
+                        createdInvoiceId = invoiceId
+                    )
+                }
+            } catch (t: Throwable) {
+                _state.update {
+                    it.copy(
+                        isSaving = false,
+                        error = t.message ?: "Error al crear la orden"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/selliaapp/viewmodel/QuickStockAdjustViewModel.kt
+++ b/app/src/main/java/com/example/selliaapp/viewmodel/QuickStockAdjustViewModel.kt
@@ -1,0 +1,129 @@
+package com.example.selliaapp.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.selliaapp.data.local.entity.ProductEntity
+import com.example.selliaapp.data.model.stock.StockAdjustmentReason
+import com.example.selliaapp.data.model.stock.StockMovementReasons
+import com.example.selliaapp.data.model.stock.StockMovementWithProduct
+import com.example.selliaapp.repository.IProductRepository
+import com.example.selliaapp.ui.navigation.Routes
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+private val movementFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("dd/MM HH:mm").withZone(ZoneId.systemDefault())
+
+data class QuickAdjustUiState(
+    val loading: Boolean = true,
+    val product: ProductEntity? = null,
+    val deltaText: String = "",
+    val selectedReason: StockAdjustmentReason = StockAdjustmentReason.INVENTORY,
+    val note: String = "",
+    val isSaving: Boolean = false,
+    val error: String? = null,
+    val success: Boolean = false,
+    val recentMovements: List<StockMovementWithProduct> = emptyList()
+) {
+    val formattedMovements: List<String>
+        get() = recentMovements.map {
+            val direction = if (it.delta >= 0) "+${it.delta}" else it.delta.toString()
+            val reason = StockMovementReasons.humanReadable(it.reason)
+            val ts = movementFormatter.format(it.ts)
+            val notePart = it.note?.takeIf { n -> n.isNotBlank() }?.let { n -> " • $n" } ?: ""
+            "$ts • $direction • $reason$notePart"
+        }
+}
+
+@HiltViewModel
+class QuickStockAdjustViewModel @Inject constructor(
+    private val repo: IProductRepository,
+    savedStateHandle: SavedStateHandle
+) : ViewModel() {
+
+    private val productId: Int = checkNotNull(
+        savedStateHandle.get<Int>(Routes.QuickAdjustStock.ARG_PRODUCT_ID)
+    )
+
+    private val _state = MutableStateFlow(QuickAdjustUiState())
+    val state: StateFlow<QuickAdjustUiState> = _state.asStateFlow()
+
+    init {
+        loadProduct()
+        observeMovements()
+    }
+
+    private fun loadProduct() {
+        viewModelScope.launch {
+            val product = repo.getById(productId)
+            val deficit = product?.let { p ->
+                val min = p.minStock ?: 0
+                val current = p.quantity
+                val missing = (min - current).coerceAtLeast(0)
+                if (missing > 0) missing.toString() else ""
+            } ?: ""
+            _state.update {
+                it.copy(
+                    loading = false,
+                    product = product,
+                    deltaText = deficit,
+                    error = if (product == null) "Producto no encontrado" else null
+                )
+            }
+        }
+    }
+
+    private fun observeMovements() {
+        viewModelScope.launch {
+            repo.observeStockMovements(productId, limit = 5).collect { list ->
+                _state.update { it.copy(recentMovements = list) }
+            }
+        }
+    }
+
+    fun onDeltaChange(value: String) {
+        _state.update { it.copy(deltaText = value, error = null, success = false) }
+    }
+
+    fun onReasonSelected(reason: StockAdjustmentReason) {
+        _state.update { it.copy(selectedReason = reason, success = false) }
+    }
+
+    fun onNoteChange(note: String) {
+        _state.update { it.copy(note = note, success = false) }
+    }
+
+    fun submit() {
+        val product = state.value.product ?: return
+        val delta = state.value.deltaText.toIntOrNull()
+        if (delta == null || delta == 0) {
+            _state.update { it.copy(error = "Ingresá una cantidad distinta de cero") }
+            return
+        }
+        viewModelScope.launch {
+            _state.update { it.copy(isSaving = true, error = null) }
+            val note = state.value.note.trim().takeIf { it.isNotEmpty() }
+            val success = repo.adjustStock(
+                productId = product.id,
+                delta = delta,
+                reason = state.value.selectedReason.code,
+                note = note
+            )
+            _state.update {
+                it.copy(
+                    isSaving = false,
+                    success = success,
+                    error = if (success) null else "No se pudo registrar el ajuste"
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/selliaapp/viewmodel/StockMovementsViewModel.kt
+++ b/app/src/main/java/com/example/selliaapp/viewmodel/StockMovementsViewModel.kt
@@ -1,0 +1,48 @@
+package com.example.selliaapp.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.selliaapp.data.model.stock.StockMovementReasons
+import com.example.selliaapp.data.model.stock.StockMovementWithProduct
+import com.example.selliaapp.repository.IProductRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.SharingStarted
+import javax.inject.Inject
+
+data class StockMovementsUiState(
+    val loading: Boolean = true,
+    val movements: List<StockMovementWithProduct> = emptyList(),
+    val allReasons: List<String> = emptyList(),
+    val selectedReason: String? = null
+)
+
+@HiltViewModel
+class StockMovementsViewModel @Inject constructor(
+    private val productRepository: IProductRepository
+) : ViewModel() {
+
+    private val selectedReason = MutableStateFlow<String?>(null)
+
+    private val baseFlow = productRepository.observeRecentStockMovements(limit = 100)
+
+    val state: StateFlow<StockMovementsUiState> = combine(baseFlow, selectedReason) { movements, reason ->
+        val reasons = movements.map { it.reason }.distinct()
+        val filtered = reason?.let { r -> movements.filter { it.reason == r } } ?: movements
+        StockMovementsUiState(
+            loading = false,
+            movements = filtered,
+            allReasons = reasons,
+            selectedReason = reason
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, StockMovementsUiState())
+
+    fun selectReason(reason: String?) {
+        selectedReason.value = reason
+    }
+
+    fun readableReason(code: String): String = StockMovementReasons.humanReadable(code)
+}


### PR DESCRIPTION
## Summary
- add a Room outbox table and DAO to persist pending entities for synchronization
- wire invoice persistence to enqueue outbox entries, retry failures, and reuse the same logic for legacy flows
- update the sync repository/worker to push only pending entities, pull invoices from Firestore, and log sync outcomes

## Testing
- `./gradlew test` *(fails: Android SDK not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e50595d9888323a171eccef727196d